### PR TITLE
Fix tag format for NotificationRule

### DIFF
--- a/src/aspects/notification-rule-tags.ts
+++ b/src/aspects/notification-rule-tags.ts
@@ -1,0 +1,24 @@
+import * as cdk from 'aws-cdk-lib';
+import { IConstruct } from 'constructs';
+import * as notifications from 'aws-cdk-lib/aws-codestarnotifications';
+
+/**
+ * Fix tag format for `AWS::CodeStarNotifications::NotificationRule` resources.
+ *
+ * Some CloudFormation versions expect the `Tags` property to be an array of
+ * key/value pairs, but CDK currently renders these tags as a map under the
+ * `tags` property. This aspect converts the tags to the correct format and
+ * removes the original property.
+ */
+export class NotificationRuleTagFixer implements cdk.IAspect {
+  public visit(node: IConstruct): void {
+    if (node instanceof notifications.CfnNotificationRule) {
+      const tags = node.tags.tagValues();
+      if (Object.keys(tags).length > 0) {
+        const list = Object.entries(tags).map(([Key, Value]) => ({ Key, Value }));
+        node.addOverride('Properties.Tags', list);
+        node.addDeletionOverride('Properties.tags');
+      }
+    }
+  }
+}

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -31,6 +31,7 @@ import { StatusFunction } from './status-function';
 import { TokenRetrieverFunction } from './token-retriever-function';
 import { singletonLogGroup, SingletonLogType } from './utils';
 import { GithubWebhookHandler } from './webhook';
+import { NotificationRuleTagFixer } from './aspects/notification-rule-tags';
 
 
 /**
@@ -773,6 +774,8 @@ export class GitHubRunners extends Construct implements ec2.IConnectable {
         AwsImageBuilderFailedBuildNotifier.createFilteringTopic(this, topic),
       ),
     );
+    // Ensure notification rules use the correct tag format
+    cdk.Aspects.of(stack).add(new NotificationRuleTagFixer());
     return topic;
   }
 


### PR DESCRIPTION
## Summary
- convert NotificationRule tags to key/value list via new aspect
- apply aspect in runner stack

## Testing
- `npx projen compile`
- `npx projen test` *(fails: Cannot find asset)*